### PR TITLE
277 학번 공유 UI 변경

### DIFF
--- a/src/components/chat/ChatItemMy.tsx
+++ b/src/components/chat/ChatItemMy.tsx
@@ -5,9 +5,10 @@ type Props = {
   time: string;
   imageUrls?: string[];
   onMessageClick?: () => void;
+  onImageClick?: (url: string) => void;
 };
 
-const ChatItemMy = ({ content, time, imageUrls, onMessageClick }: Props) => {
+const ChatItemMy = ({ content, time, imageUrls, onMessageClick, onImageClick }: Props) => {
   return (
     <ChatItemMyWrapper
       onClick={onMessageClick}
@@ -17,7 +18,17 @@ const ChatItemMy = ({ content, time, imageUrls, onMessageClick }: Props) => {
         {imageUrls?.length ? (
           <ImageGrid>
             {imageUrls.map((url) => (
-              <img key={url} src={url} alt="첨부 사진" />
+              <img
+                key={url}
+                src={url}
+                alt="첨부 사진"
+                onClick={(e) => {
+                  if (onImageClick) {
+                    e.stopPropagation();
+                    onImageClick(url);
+                  }
+                }}
+              />
             ))}
           </ImageGrid>
         ) : (
@@ -58,6 +69,7 @@ const ImageGrid = styled.div`
     max-height: 220px;
     object-fit: cover;
     display: block;
+    cursor: pointer;
   }
   img:only-child {
     grid-column: 1 / -1;

--- a/src/components/chat/ChatItemOtherPerson.tsx
+++ b/src/components/chat/ChatItemOtherPerson.tsx
@@ -1,5 +1,6 @@
 import styled from "styled-components";
 import profile from "../../assets/profileimg.png";
+import { useLongPress } from "@/hooks/useLongPress";
 
 type Props = {
   content: string;
@@ -18,9 +19,16 @@ const ChatItemOtherPerson = ({
   imageUrls,
   onMessageClick,
 }: Props) => {
+  const longPressHandlers = useLongPress({
+    onLongPress: () => {
+      if (onMessageClick) onMessageClick();
+    },
+    delay: 500,
+  });
+
   return (
     <ChatItemOtherPersonWrapper
-      onClick={onMessageClick}
+      {...(onMessageClick ? longPressHandlers : {})}
       $clickable={Boolean(onMessageClick)}
     >
       <ProfileImg

--- a/src/components/chat/ChatItemOtherPerson.tsx
+++ b/src/components/chat/ChatItemOtherPerson.tsx
@@ -27,10 +27,7 @@ const ChatItemOtherPerson = ({
   });
 
   return (
-    <ChatItemOtherPersonWrapper
-      {...(onMessageClick ? longPressHandlers : {})}
-      $clickable={Boolean(onMessageClick)}
-    >
+    <ChatItemOtherPersonWrapper>
       <ProfileImg
         src={userImageUrl && userImageUrl !== "string" ? userImageUrl : profile}
         alt="상대방"
@@ -42,13 +39,21 @@ const ChatItemOtherPerson = ({
       <ContentArea>
         {senderName && <div className="sender-name">{senderName}</div>}
         {imageUrls?.length ? (
-          <ImageGrid>
+          <ImageGrid
+            {...(onMessageClick ? longPressHandlers : {})}
+            $clickable={Boolean(onMessageClick)}
+          >
             {imageUrls.map((url) => (
               <img key={url} src={url} alt="첨부 사진" />
             ))}
           </ImageGrid>
         ) : (
-          <div className="message">{content}</div>
+          <MessageBubble
+            {...(onMessageClick ? longPressHandlers : {})}
+            $clickable={Boolean(onMessageClick)}
+          >
+            {content}
+          </MessageBubble>
         )}
       </ContentArea>
       <TimeArea>
@@ -60,7 +65,7 @@ const ChatItemOtherPerson = ({
 
 export default ChatItemOtherPerson;
 
-const ChatItemOtherPersonWrapper = styled.div<{ $clickable: boolean }>`
+const ChatItemOtherPersonWrapper = styled.div`
   width: 100%;
   height: fit-content;
   display: flex;
@@ -70,15 +75,17 @@ const ChatItemOtherPersonWrapper = styled.div<{ $clickable: boolean }>`
   box-sizing: border-box;
 
   gap: 8px;
-  cursor: ${({ $clickable }) => ($clickable ? "pointer" : "default")};
 `;
 
-const ImageGrid = styled.div`
+const ImageGrid = styled.div<{ $clickable?: boolean }>`
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 140px));
   gap: 4px;
   overflow: hidden;
   border-radius: 16px;
+  cursor: ${({ $clickable }) => ($clickable ? "pointer" : "default")};
+  transition: transform 0.15s ease, filter 0.15s ease;
+
   img {
     width: 100%;
     max-height: 220px;
@@ -89,17 +96,26 @@ const ImageGrid = styled.div`
     grid-column: 1 / -1;
     min-width: 140px;
   }
+
+  &:active {
+    ${({ $clickable }) =>
+      $clickable &&
+      `
+      transform: scale(0.97);
+      filter: brightness(0.92);
+    `}
+  }
 `;
+
 const ProfileImg = styled.img`
-  //padding-top: 3px;
   width: 30px;
   height: 30px;
   border-radius: 50%;
   object-fit: cover;
   flex-shrink: 0;
 `;
+
 const ContentArea = styled.div`
-  //flex: 1;
   width: fit-content;
   max-width: 60%;
   display: flex;
@@ -113,19 +129,30 @@ const ContentArea = styled.div`
     margin-bottom: 4px;
     padding-left: 4px;
   }
+`;
 
-  .message {
-    font-family: "Pretendard", sans-serif;
-    font-style: normal;
-    font-weight: 400;
-    font-size: 14px;
-    line-height: 1.5;
-    text-align: start;
+const MessageBubble = styled.div<{ $clickable?: boolean }>`
+  font-family: "Pretendard", sans-serif;
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 1.5;
+  text-align: start;
 
-    color: #3d3d3d;
-    background: #f7f7f7;
-    padding: 8px 12px;
-    border-radius: 16px;
+  color: #3d3d3d;
+  background: #f7f7f7;
+  padding: 8px 12px;
+  border-radius: 16px;
+  cursor: ${({ $clickable }) => ($clickable ? "pointer" : "default")};
+  transition: transform 0.15s ease, background-color 0.15s ease;
+
+  &:active {
+    ${({ $clickable }) =>
+      $clickable &&
+      `
+      transform: scale(0.97);
+      background-color: #e5e5e5;
+    `}
   }
 `;
 

--- a/src/components/chat/ChatItemOtherPerson.tsx
+++ b/src/components/chat/ChatItemOtherPerson.tsx
@@ -9,6 +9,7 @@ type Props = {
   senderName?: string;
   imageUrls?: string[];
   onMessageClick?: () => void;
+  onImageClick?: (url: string) => void;
 };
 
 const ChatItemOtherPerson = ({
@@ -18,6 +19,7 @@ const ChatItemOtherPerson = ({
   senderName,
   imageUrls,
   onMessageClick,
+  onImageClick,
 }: Props) => {
   const longPressHandlers = useLongPress({
     onLongPress: () => {
@@ -44,7 +46,17 @@ const ChatItemOtherPerson = ({
             $clickable={Boolean(onMessageClick)}
           >
             {imageUrls.map((url) => (
-              <img key={url} src={url} alt="첨부 사진" />
+              <img
+                key={url}
+                src={url}
+                alt="첨부 사진"
+                onClick={(e) => {
+                  if (onImageClick) {
+                    e.stopPropagation();
+                    onImageClick(url);
+                  }
+                }}
+              />
             ))}
           </ImageGrid>
         ) : (

--- a/src/components/chat/ImageViewerModal.tsx
+++ b/src/components/chat/ImageViewerModal.tsx
@@ -1,0 +1,93 @@
+import { useEffect } from "react";
+import styled from "styled-components";
+import { X } from "lucide-react";
+
+interface Props {
+  imageUrl: string | null;
+  onClose: () => void;
+}
+
+export default function ImageViewerModal({ imageUrl, onClose }: Props) {
+  useEffect(() => {
+    if (!imageUrl) return;
+
+    // 히스토리에 현재 모달 상태 push (뒤로가기 키 대응)
+    window.history.pushState({ imageViewerOpen: true }, "");
+
+    const handlePopState = () => {
+      onClose();
+    };
+
+    window.addEventListener("popstate", handlePopState);
+
+    return () => {
+      window.removeEventListener("popstate", handlePopState);
+      // 모달이 수동 닫힘(X 버튼이나 배경 클릭)으로 해제될 때 추가했던 히스토리 back 처리
+      if (window.history.state?.imageViewerOpen) {
+        window.history.back();
+      }
+    };
+  }, [imageUrl, onClose]);
+
+  if (!imageUrl) return null;
+
+  return (
+    <Overlay onClick={onClose}>
+      <CloseButton onClick={onClose} aria-label="닫기">
+        <X size={24} color="#ffffff" />
+      </CloseButton>
+      <ImageContainer onClick={(e) => e.stopPropagation()}>
+        <FullImage src={imageUrl} alt="확대 이미지" />
+      </ImageContainer>
+    </Overlay>
+  );
+}
+
+const Overlay = styled.div`
+  position: fixed;
+  inset: 0;
+  z-index: 30000;
+  background-color: rgba(0, 0, 0, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  user-select: none;
+`;
+
+const CloseButton = styled.button`
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  background: rgba(255, 255, 255, 0.15);
+  border: none;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 30001;
+  transition: background-color 0.2s;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.3);
+  }
+`;
+
+const ImageContainer = styled.div`
+  max-width: 100%;
+  max-height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+  box-sizing: border-box;
+`;
+
+const FullImage = styled.img`
+  max-width: 100%;
+  max-height: 90vh;
+  object-fit: contain;
+  border-radius: 8px;
+`;

--- a/src/components/chat/ImageViewerModal.tsx
+++ b/src/components/chat/ImageViewerModal.tsx
@@ -1,4 +1,3 @@
-import { useEffect } from "react";
 import styled from "styled-components";
 import { X } from "lucide-react";
 
@@ -8,38 +7,11 @@ interface Props {
 }
 
 export default function ImageViewerModal({ imageUrl, onClose }: Props) {
-  useEffect(() => {
-    if (!imageUrl) return;
-
-    // 모달 오픈 시 히스토리에 가짜 스택 push
-    window.history.pushState({ imageViewer: true }, "");
-
-    const handlePopState = (e: PopStateEvent) => {
-      // 뒤로가기 누르면 닫기
-      onClose();
-    };
-
-    window.addEventListener("popstate", handlePopState);
-
-    return () => {
-      window.removeEventListener("popstate", handlePopState);
-    };
-  }, [imageUrl, onClose]);
-
-  const handleClose = () => {
-    // 수동 닫기 시 push했던 history 되돌리기 (뒤로가기를 한 번 실행하면 popstate가 발생하여 handlePopState -> onClose 호출됨)
-    if (window.history.state?.imageViewer) {
-      window.history.back();
-    } else {
-      onClose();
-    }
-  };
-
   if (!imageUrl) return null;
 
   return (
-    <Overlay onClick={handleClose}>
-      <CloseButton onClick={handleClose} aria-label="닫기">
+    <Overlay onClick={onClose}>
+      <CloseButton onClick={onClose} aria-label="닫기">
         <X size={24} color="#ffffff" />
       </CloseButton>
       <ImageContainer onClick={(e) => e.stopPropagation()}>

--- a/src/components/chat/ImageViewerModal.tsx
+++ b/src/components/chat/ImageViewerModal.tsx
@@ -11,11 +11,11 @@ export default function ImageViewerModal({ imageUrl, onClose }: Props) {
   useEffect(() => {
     if (!imageUrl) return;
 
-    // 히스토리 가짜 엔트리 추가
-    window.history.pushState({ modalOpen: true }, "");
+    // 모달 오픈 시 히스토리에 가짜 스택 push
+    window.history.pushState({ imageViewer: true }, "");
 
-    const handlePopState = () => {
-      // 브라우저/네이티브 뒤로가기 실행 시 모달 닫기
+    const handlePopState = (e: PopStateEvent) => {
+      // 뒤로가기 누르면 닫기
       onClose();
     };
 
@@ -27,8 +27,8 @@ export default function ImageViewerModal({ imageUrl, onClose }: Props) {
   }, [imageUrl, onClose]);
 
   const handleClose = () => {
-    // 버튼/배경 직접 클릭으로 닫힐 때는 생성했던 history state 제거를 위해 back 실행
-    if (window.history.state?.modalOpen) {
+    // 수동 닫기 시 push했던 history 되돌리기 (뒤로가기를 한 번 실행하면 popstate가 발생하여 handlePopState -> onClose 호출됨)
+    if (window.history.state?.imageViewer) {
       window.history.back();
     } else {
       onClose();

--- a/src/components/chat/ImageViewerModal.tsx
+++ b/src/components/chat/ImageViewerModal.tsx
@@ -10,7 +10,7 @@ export default function ImageViewerModal({ imageUrl, onClose }: Props) {
   if (!imageUrl) return null;
 
   return (
-    <Overlay onClick={onClose}>
+    <Overlay>
       <CloseButton onClick={onClose} aria-label="닫기">
         <X size={24} color="#ffffff" />
       </CloseButton>

--- a/src/components/chat/ImageViewerModal.tsx
+++ b/src/components/chat/ImageViewerModal.tsx
@@ -11,10 +11,11 @@ export default function ImageViewerModal({ imageUrl, onClose }: Props) {
   useEffect(() => {
     if (!imageUrl) return;
 
-    // 히스토리에 현재 모달 상태 push (뒤로가기 키 대응)
-    window.history.pushState({ imageViewerOpen: true }, "");
+    // 히스토리 가짜 엔트리 추가
+    window.history.pushState({ modalOpen: true }, "");
 
     const handlePopState = () => {
+      // 브라우저/네이티브 뒤로가기 실행 시 모달 닫기
       onClose();
     };
 
@@ -22,18 +23,23 @@ export default function ImageViewerModal({ imageUrl, onClose }: Props) {
 
     return () => {
       window.removeEventListener("popstate", handlePopState);
-      // 모달이 수동 닫힘(X 버튼이나 배경 클릭)으로 해제될 때 추가했던 히스토리 back 처리
-      if (window.history.state?.imageViewerOpen) {
-        window.history.back();
-      }
     };
   }, [imageUrl, onClose]);
+
+  const handleClose = () => {
+    // 버튼/배경 직접 클릭으로 닫힐 때는 생성했던 history state 제거를 위해 back 실행
+    if (window.history.state?.modalOpen) {
+      window.history.back();
+    } else {
+      onClose();
+    }
+  };
 
   if (!imageUrl) return null;
 
   return (
-    <Overlay onClick={onClose}>
-      <CloseButton onClick={onClose} aria-label="닫기">
+    <Overlay onClick={handleClose}>
+      <CloseButton onClick={handleClose} aria-label="닫기">
         <X size={24} color="#ffffff" />
       </CloseButton>
       <ImageContainer onClick={(e) => e.stopPropagation()}>

--- a/src/hooks/useLongPress.ts
+++ b/src/hooks/useLongPress.ts
@@ -1,0 +1,35 @@
+import { useCallback, useRef } from "react";
+
+interface UseLongPressOptions {
+  onLongPress: () => void;
+  delay?: number;
+}
+
+export function useLongPress({ onLongPress, delay = 500 }: UseLongPressOptions) {
+  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const isLongPressActive = useRef(false);
+
+  const start = useCallback(() => {
+    isLongPressActive.current = false;
+    timerRef.current = setTimeout(() => {
+      isLongPressActive.current = true;
+      onLongPress();
+    }, delay);
+  }, [onLongPress, delay]);
+
+  const clear = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  return {
+    onMouseDown: start,
+    onTouchStart: start,
+    onMouseUp: clear,
+    onMouseLeave: clear,
+    onTouchEnd: clear,
+    onTouchMove: clear,
+  };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,11 +1,26 @@
 /* src/index.css */
+*, *::before, *::after {
+    -webkit-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+}
+
 html, body, #root {
     margin: 0;
     padding: 0;
     width: 100%;
     height: 100%;
     /*overscroll-behavior: contain;*/
+}
 
+input, textarea, [contenteditable="true"], .selectable {
+    -webkit-user-select: text;
+    -moz-user-select: text;
+    -ms-user-select: text;
+    user-select: text;
+    -webkit-touch-callout: default;
 }
 
 input {

--- a/src/pages/Chat/ChattingPage.styles.ts
+++ b/src/pages/Chat/ChattingPage.styles.ts
@@ -318,6 +318,7 @@ export const ShareCardSubtitle = styled.div`
 
 export const ShareCardButtonGroup = styled.div`
   display: flex;
+  justify-content: flex-end;
   gap: 12px;
 `;
 

--- a/src/pages/Chat/ChattingPage.styles.ts
+++ b/src/pages/Chat/ChattingPage.styles.ts
@@ -388,7 +388,7 @@ export const ShareSuccessInfo = styled.div`
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 0 20px;
+  padding: 0 0 0 28px;
   width: 100%;
   box-sizing: border-box;
 `;

--- a/src/pages/Chat/ChattingPage.styles.ts
+++ b/src/pages/Chat/ChattingPage.styles.ts
@@ -356,15 +356,14 @@ export const ShareCardButton = styled.button<{
 
 export const ShareSuccessCard = styled.div`
   background-color: #ffffff;
-  border: 1px solid #bae0ff;
+  border: 1px solid #dfdfdf;
   border-radius: 16px;
   padding: 16px;
   width: 100%;
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
-  gap: 12px;
-  box-shadow: 0px 4px 12px rgba(22, 119, 255, 0.05);
+  gap: 16px;
 
   @media (min-width: 768px) {
     max-width: 320px;
@@ -372,50 +371,58 @@ export const ShareSuccessCard = styled.div`
 `;
 
 export const ShareSuccessTitle = styled.div`
-  font-family: "Pretendard", sans-serif;
-  font-size: 15px;
-  font-weight: 600;
-  color: #0958d9;
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
+  font-family: "Pretendard", sans-serif;
+  font-size: 16px;
+  font-weight: 600;
+  line-height: 1.5;
+  color: #3d3d3d;
   margin: 0;
+  white-space: nowrap;
 `;
 
 export const ShareSuccessInfo = styled.div`
   display: flex;
-  justify-content: space-around;
-  align-items: center;
-  background-color: #f0f5ff;
-  border: 1px solid #adc6ff;
-  border-radius: 12px;
-  padding: 12px;
+  flex-direction: column;
+  gap: 8px;
+  padding: 0 20px;
+  width: 100%;
+  box-sizing: border-box;
 `;
 
-export const ShareSuccessInfoItem = styled.div`
+export const ShareSuccessInfoRow = styled.div`
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 16px;
+  line-height: 1.5;
 
   .label {
+    width: 37px;
     font-family: "Pretendard", sans-serif;
-    font-size: 11px;
-    color: #8b8b8b;
+    font-size: 14px;
+    font-weight: 400;
+    color: #3d3d3d;
+    flex-shrink: 0;
+  }
+
+  .label-other {
+    font-family: "Pretendard", sans-serif;
+    font-size: 14px;
+    font-weight: 400;
+    color: #3d3d3d;
+    flex-shrink: 0;
   }
 
   .value {
     font-family: "Pretendard", sans-serif;
     font-size: 16px;
-    font-weight: 700;
-    color: #1677ff;
+    font-weight: 600;
+    color: #3d3d3d;
+    white-space: nowrap;
+    flex-shrink: 0;
   }
-`;
-
-export const ShareSuccessInfoDivider = styled.div`
-  width: 1px;
-  height: 24px;
-  background-color: #adc6ff;
 `;
 
 export const ShareSystemMessage = styled.div`

--- a/src/pages/Chat/ChattingPage.tsx
+++ b/src/pages/Chat/ChattingPage.tsx
@@ -181,19 +181,25 @@ export default function ChattingPage() {
     : null;
 
   const handleImageClick = (url: string) => {
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev);
-      next.set("viewImg", encodeURIComponent(url));
-      return next;
-    });
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set("viewImg", encodeURIComponent(url));
+        return next;
+      },
+      { replace: true }
+    );
   };
 
   const handleCloseImageModal = () => {
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev);
-      next.delete("viewImg");
-      return next;
-    }, { replace: true });
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("viewImg");
+        return next;
+      },
+      { replace: true }
+    );
   };
   const [isOpenChatHost, setIsOpenChatHost] = useState(false);
   const menuContainerRef = useRef<HTMLDivElement>(null);

--- a/src/pages/Chat/ChattingPage.tsx
+++ b/src/pages/Chat/ChattingPage.tsx
@@ -1,4 +1,4 @@
-import { useLocation, useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { useEffect, useRef, useState } from "react";
 import React from "react";
 import ChatInfo from "../../components/chat/ChatInfo.tsx";
@@ -175,7 +175,23 @@ export default function ChattingPage() {
   const [selectedMessage, setSelectedMessage] = useState<MessageType | null>(
     null,
   );
-  const [selectedImageUrl, setSelectedImageUrl] = useState<string | null>(null);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedImageUrl = searchParams.get("viewImg")
+    ? decodeURIComponent(searchParams.get("viewImg")!)
+    : null;
+
+  const handleImageClick = (url: string) => {
+    setSearchParams((prev) => {
+      prev.set("viewImg", encodeURIComponent(url));
+      return prev;
+    });
+  };
+
+  const handleCloseImageModal = () => {
+    if (searchParams.has("viewImg")) {
+      navigate(-1);
+    }
+  };
   const [isOpenChatHost, setIsOpenChatHost] = useState(false);
   const menuContainerRef = useRef<HTMLDivElement>(null);
 
@@ -997,7 +1013,7 @@ export default function ChattingPage() {
                       content={msg.content}
                       time={msg.time}
                       imageUrls={msg.imageUrls}
-                      onImageClick={(url) => setSelectedImageUrl(url)}
+                      onImageClick={handleImageClick}
                     />
                   ) : (
                     <ChatItemOtherPerson
@@ -1011,7 +1027,7 @@ export default function ChattingPage() {
                       }
                       imageUrls={msg.imageUrls}
                       onMessageClick={() => openMessageActions(msg)}
-                      onImageClick={(url) => setSelectedImageUrl(url)}
+                      onImageClick={handleImageClick}
                     />
                   )}
                 </React.Fragment>
@@ -1090,7 +1106,7 @@ export default function ChattingPage() {
 
       <ImageViewerModal
         imageUrl={selectedImageUrl}
-        onClose={() => setSelectedImageUrl(null)}
+        onClose={handleCloseImageModal}
       />
     </S.ChatPageWrapper>
   );

--- a/src/pages/Chat/ChattingPage.tsx
+++ b/src/pages/Chat/ChattingPage.tsx
@@ -945,21 +945,20 @@ export default function ChattingPage() {
                   const cardContent = (
                     <S.ShareSuccessCard>
                       <S.ShareSuccessTitle>
-                        <CheckCircle2 size={18} color="#52c41a" />
+                        <CheckCircle2 size={20} color="#3D3D3D" />
                         학번 공유 완료
                       </S.ShareSuccessTitle>
                       <S.ShareSuccessInfo>
-                        <S.ShareSuccessInfoItem>
-                          <span className="label">상대방</span>
+                        <S.ShareSuccessInfoRow>
+                          <span className="label">나</span>
+                          <span className="value">{myNum || "알 수 없음"}</span>
+                        </S.ShareSuccessInfoRow>
+                        <S.ShareSuccessInfoRow>
+                          <span className="label-other">상대방</span>
                           <span className="value">
                             {partnerNum || "알 수 없음"}
                           </span>
-                        </S.ShareSuccessInfoItem>
-                        <S.ShareSuccessInfoDivider />
-                        <S.ShareSuccessInfoItem>
-                          <span className="label">나</span>
-                          <span className="value">{myNum || "알 수 없음"}</span>
-                        </S.ShareSuccessInfoItem>
+                        </S.ShareSuccessInfoRow>
                       </S.ShareSuccessInfo>
                     </S.ShareSuccessCard>
                   );
@@ -980,36 +979,8 @@ export default function ChattingPage() {
                   );
                 }
 
-                if (parsed.type === "CANCEL") {
-                  return (
-                    <React.Fragment key={msg.id}>
-                      {showDateLine && (
-                        <S.DateDivider>
-                          {formatDateLine(msg.createdAt)}
-                        </S.DateDivider>
-                      )}
-                      <S.ShareSystemMessage>
-                        <XCircle size={14} color="#8b8b8b" />
-                        학번 공유 요청이 취소되었어요.
-                      </S.ShareSystemMessage>
-                    </React.Fragment>
-                  );
-                }
-
-                if (parsed.type === "DECLINE") {
-                  return (
-                    <React.Fragment key={msg.id}>
-                      {showDateLine && (
-                        <S.DateDivider>
-                          {formatDateLine(msg.createdAt)}
-                        </S.DateDivider>
-                      )}
-                      <S.ShareSystemMessage>
-                        <XCircle size={14} color="#8b8b8b" />
-                        학번 공유 요청이 거절되었어요.
-                      </S.ShareSystemMessage>
-                    </React.Fragment>
-                  );
+                if (parsed.type === "CANCEL" || parsed.type === "DECLINE") {
+                  return null;
                 }
               }
 

--- a/src/pages/Chat/ChattingPage.tsx
+++ b/src/pages/Chat/ChattingPage.tsx
@@ -182,15 +182,18 @@ export default function ChattingPage() {
 
   const handleImageClick = (url: string) => {
     setSearchParams((prev) => {
-      prev.set("viewImg", encodeURIComponent(url));
-      return prev;
+      const next = new URLSearchParams(prev);
+      next.set("viewImg", encodeURIComponent(url));
+      return next;
     });
   };
 
   const handleCloseImageModal = () => {
-    if (searchParams.has("viewImg")) {
-      navigate(-1);
-    }
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete("viewImg");
+      return next;
+    }, { replace: true });
   };
   const [isOpenChatHost, setIsOpenChatHost] = useState(false);
   const menuContainerRef = useRef<HTMLDivElement>(null);

--- a/src/pages/Chat/ChattingPage.tsx
+++ b/src/pages/Chat/ChattingPage.tsx
@@ -181,25 +181,17 @@ export default function ChattingPage() {
     : null;
 
   const handleImageClick = (url: string) => {
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        next.set("viewImg", encodeURIComponent(url));
-        return next;
-      },
-      { replace: true }
-    );
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.set("viewImg", encodeURIComponent(url));
+      return next;
+    });
   };
 
   const handleCloseImageModal = () => {
-    setSearchParams(
-      (prev) => {
-        const next = new URLSearchParams(prev);
-        next.delete("viewImg");
-        return next;
-      },
-      { replace: true }
-    );
+    if (searchParams.has("viewImg")) {
+      navigate(-1);
+    }
   };
   const [isOpenChatHost, setIsOpenChatHost] = useState(false);
   const menuContainerRef = useRef<HTMLDivElement>(null);

--- a/src/pages/Chat/ChattingPage.tsx
+++ b/src/pages/Chat/ChattingPage.tsx
@@ -189,9 +189,11 @@ export default function ChattingPage() {
   };
 
   const handleCloseImageModal = () => {
-    if (searchParams.has("viewImg")) {
-      navigate(-1);
-    }
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete("viewImg");
+      return next;
+    });
   };
   const [isOpenChatHost, setIsOpenChatHost] = useState(false);
   const menuContainerRef = useRef<HTMLDivElement>(null);

--- a/src/pages/Chat/ChattingPage.tsx
+++ b/src/pages/Chat/ChattingPage.tsx
@@ -175,26 +175,7 @@ export default function ChattingPage() {
   const [selectedMessage, setSelectedMessage] = useState<MessageType | null>(
     null,
   );
-  const [searchParams, setSearchParams] = useSearchParams();
-  const selectedImageUrl = searchParams.get("viewImg")
-    ? decodeURIComponent(searchParams.get("viewImg")!)
-    : null;
-
-  const handleImageClick = (url: string) => {
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev);
-      next.set("viewImg", encodeURIComponent(url));
-      return next;
-    });
-  };
-
-  const handleCloseImageModal = () => {
-    setSearchParams((prev) => {
-      const next = new URLSearchParams(prev);
-      next.delete("viewImg");
-      return next;
-    });
-  };
+  const [selectedImageUrl, setSelectedImageUrl] = useState<string | null>(null);
   const [isOpenChatHost, setIsOpenChatHost] = useState(false);
   const menuContainerRef = useRef<HTMLDivElement>(null);
 
@@ -1016,7 +997,7 @@ export default function ChattingPage() {
                       content={msg.content}
                       time={msg.time}
                       imageUrls={msg.imageUrls}
-                      onImageClick={handleImageClick}
+                      onImageClick={(url) => setSelectedImageUrl(url)}
                     />
                   ) : (
                     <ChatItemOtherPerson
@@ -1030,7 +1011,7 @@ export default function ChattingPage() {
                       }
                       imageUrls={msg.imageUrls}
                       onMessageClick={() => openMessageActions(msg)}
-                      onImageClick={handleImageClick}
+                      onImageClick={(url) => setSelectedImageUrl(url)}
                     />
                   )}
                 </React.Fragment>
@@ -1109,7 +1090,7 @@ export default function ChattingPage() {
 
       <ImageViewerModal
         imageUrl={selectedImageUrl}
-        onClose={handleCloseImageModal}
+        onClose={() => setSelectedImageUrl(null)}
       />
     </S.ChatPageWrapper>
   );

--- a/src/pages/Chat/ChattingPage.tsx
+++ b/src/pages/Chat/ChattingPage.tsx
@@ -19,6 +19,7 @@ import { createReport } from "@/apis/report";
 import { OpenChatKickReason, OpenChatMessage } from "@/types/openchat";
 import PhotoAttachmentBottomSheet from "@/components/chat/PhotoAttachmentBottomSheet";
 import ChatMessageActionSheet from "@/components/chat/ChatMessageActionSheet";
+import ImageViewerModal from "@/components/chat/ImageViewerModal";
 import { useSetHeader } from "@/hooks/useSetHeader";
 import LoadingSpinner from "@/components/common/LoadingSpinner";
 import {
@@ -174,6 +175,7 @@ export default function ChattingPage() {
   const [selectedMessage, setSelectedMessage] = useState<MessageType | null>(
     null,
   );
+  const [selectedImageUrl, setSelectedImageUrl] = useState<string | null>(null);
   const [isOpenChatHost, setIsOpenChatHost] = useState(false);
   const menuContainerRef = useRef<HTMLDivElement>(null);
 
@@ -995,6 +997,7 @@ export default function ChattingPage() {
                       content={msg.content}
                       time={msg.time}
                       imageUrls={msg.imageUrls}
+                      onImageClick={(url) => setSelectedImageUrl(url)}
                     />
                   ) : (
                     <ChatItemOtherPerson
@@ -1008,6 +1011,7 @@ export default function ChattingPage() {
                       }
                       imageUrls={msg.imageUrls}
                       onMessageClick={() => openMessageActions(msg)}
+                      onImageClick={(url) => setSelectedImageUrl(url)}
                     />
                   )}
                 </React.Fragment>
@@ -1082,6 +1086,11 @@ export default function ChattingPage() {
         canKick={isOpenChatHost}
         onReport={handleReportMessage}
         onKick={handleKickSender}
+      />
+
+      <ImageViewerModal
+        imageUrl={selectedImageUrl}
+        onClose={() => setSelectedImageUrl(null)}
       />
     </S.ChatPageWrapper>
   );

--- a/src/pages/Chat/ChattingPage.tsx
+++ b/src/pages/Chat/ChattingPage.tsx
@@ -27,7 +27,6 @@ import {
   Info,
   ArrowRight,
   CheckCircle2,
-  XCircle,
 } from "lucide-react";
 import * as S from "./ChattingPage.styles";
 import {


### PR DESCRIPTION
- 피그마 디자인 스펙 기반 학번 공유 결과 카드 스타일(색상, 테두리, 여백, 텍스트 정렬) 수정
- 학번 공유 카드 내 수락/거절/취소 버튼 위치를 우측 하단으로 변경
- 학번 공유 결과 카드 내 학번 정보 텍스트 위치를 제목 시작 라인에 수직 정렬
- 학번 공유 요청 거절/취소 시 중복되는 시스템 메시지 렌더링 제거
- 앱 전역 텍스트 드래그 및 선택 방지 스타일 적용 (`user-select: none`)
- 채팅 아이템 롱 프레스 감지 타이머 훅(`useLongPress`) 구현 및 바텀시트 즉시 호출 처리
- 롱 프레스 대상 영역을 메시지 말풍선/이미지로 제한 및 누름 visual 효과(scale, background) 추가
- 채팅 내 첨부 이미지 전체화면 확대 뷰어 모달(`ImageViewerModal`) 구현 및 X 버튼 닫기 처리